### PR TITLE
feat: separate concerns in entrypoints

### DIFF
--- a/ctrs/coreutils/default.nix
+++ b/ctrs/coreutils/default.nix
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2023 Daniel Sampliner <samplinerD@gmail.com>
+#
+# SPDX-License-Identifier: GLWTPL
+
+{ dockerTools
+, coreutils
+
+, created ? "1970-01-01T00:00:01Z"
+}:
+dockerTools.streamLayeredImage {
+  inherit created;
+
+  name = coreutils.pname;
+  tag = coreutils.version;
+
+  contents = [ coreutils ];
+  maxLayers = 125;
+
+  config = {
+    Labels = {
+      "org.opencontainers.image.source" =
+        "https://github.com/becometheteapot/coreutils";
+    };
+  };
+}

--- a/ctrs/default.load.do
+++ b/ctrs/default.load.do
@@ -9,12 +9,15 @@ set -e
 redo-always
 redo-ifchange "$2.stream" ../manifest.json
 
-./"$2.stream" | podman image load >&2
+readonly PODMAN="${PODMAN:-podman}"
+
+./"$2.stream" | $PODMAN image load >&2
 
 read -r name tag < <(
 	# shellcheck disable=SC2016
 	jq -r --arg pkg "$2" \
-		'.[$pkg] | [.name, .tag ] |@tsv' \
+		'.[$pkg] | [.name, .tag ] | @tsv' \
 		../manifest.json
 )
-podman image tag "${name:?}:${tag:?}" "$name:latest"
+
+$PODMAN image tag "${name:?}:${tag:?}" "${repo:-localhost}/$name:latest"

--- a/ctrs/default.push.do
+++ b/ctrs/default.push.do
@@ -12,7 +12,7 @@ redo-ifchange "$2.stream" ../manifest.json
 read -r name tag < <(
 	# shellcheck disable=SC2016
 	jq -r --arg pkg "$2" \
-		'.[$pkg] | [.name, .tag ] |@tsv' \
+		'.[$pkg] | [.name, .tag ] | @tsv' \
 		../manifest.json
 )
 

--- a/ctrs/pbr/default.nix
+++ b/ctrs/pbr/default.nix
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2023 Daniel Sampliner <samplinerD@gmail.com>
+#
+# SPDX-License-Identifier: GLWTPL
+
+{ dockerTools
+, bash
+, coreutils
+, iproute2
+, writeScriptBin
+, xxHash
+
+, created ? "1970-01-01T00:00:01Z"
+}:
+let
+  pbr = writeScriptBin "pbr" (builtins.replaceStrings
+    [ "#!/usr/bin/env bash\n" ]
+    [ "#!${bash}/bin/bash\n" ]
+    (builtins.readFile ./pbr));
+in
+dockerTools.streamLayeredImage {
+  inherit created;
+  name = "pbr";
+
+  maxLayers = 125;
+
+  contents = [
+    coreutils
+    iproute2
+    pbr
+    xxHash
+  ];
+
+  config = {
+    Entrypoint = [ "pbr" ];
+    Labels = {
+      "org.opencontainers.image.source" =
+        "https://github.com/becometheteapot/socat";
+    };
+  };
+}

--- a/ctrs/pbr/pbr
+++ b/ctrs/pbr/pbr
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2023 Daniel Sampliner <samplinerD@gmail.com>
+#
+# SPDX-License-Identifier: GLWTPL
+
+export PS4='+(${BASH_SOURCE:-}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+set -eux
+
+readonly GW="${GW:?}"
+readonly NIC="${NIC:?}"
+readonly ROUTE="${ROUTE:?}"
+readonly NAME="${NAME:?}"
+
+read -r _ _ _ routeHash _ < <(xxhsum -H3 <<<"$ROUTE")
+id=$((16#$routeHash % (2 ** 31 - 256)))
+readonly id
+
+readonly rtDir=/etc/iproute2/rt_tables.d
+mkdir -p -- "$rtDir"
+printf '%d\t%s\n' "$id" "$NAME" >"$rtDir/$NAME.conf"
+
+errhandle() {
+	case "${1:?}" in
+	2) return 0 ;;
+	*) exit "$2" ;;
+	esac
+}
+
+ip route add default \
+	via "$GW" \
+	dev "$NIC" \
+	table "$NAME" \
+	proto static || errhandle $?
+
+ip rule add priority 32765 from "$ROUTE" lookup "$NAME" || errhandle $?

--- a/ctrs/qbittorrent-nox/default.nix
+++ b/ctrs/qbittorrent-nox/default.nix
@@ -5,15 +5,19 @@
 { dockerTools
 , coreutils
 , execline
-, gosu
 , qbittorrent-nox
-, shadow
 , writeTextFile
+, writeText
 
 , created ? "1970-01-01T00:00:01Z"
 }:
 let
   name = qbittorrent-nox.pname;
+
+  config = writeText "qBittorrent.conf" ''
+    [LegalNotice]
+    Accepted=true
+  '';
 
   entrypoint = writeTextFile {
     name = "entrypoint";
@@ -23,25 +27,17 @@ let
       #!${execline}/bin/execlineb -Ws1
 
       importas -D /config XDG_CONFIG_HOME XDG_CONFIG_HOME
-      importas -D /config XDG_DATA_HOME XDG_DATA_HOME
-      importas -D /cache XDG_CACHE_HOME XDG_CACHE_HOME
-      importas -D 911 PUID PUID
-      importas -D 911 PGID PGID
+      define conf ''${XDG_CONFIG_HOME}/qBittorrent/qBittorrent.conf
 
-      if { ${shadow}/bin/groupadd --gid $PGID ${name} }
-      if { ${shadow}/bin/useradd
-        --home-dir /var/empty
-        --no-create-home
-        --shell /bin/false
-        --uid $PUID
-        ${name}
-      }
-      if { ${coreutils}/bin/mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME }
-      if { ${coreutils}/bin/chown -R ''${PUID}:''${PGID}
-        $XDG_CONFIG_HOME
-        $XDG_DATA_HOME
-        $XDG_CACHE_HOME }
-      ${gosu}/bin/gosu ''${PUID}:''${PGID} $1 $@
+      ifelse { eltest -f $conf } { ${coreutils}/bin/stdbuf -oL $1 $@ }
+      ifelse
+        { ${coreutils}/bin/install -v -Dm0644 ${config} $conf }
+        { ${coreutils}/bin/stdbuf -oL $1 $@ }
+      foreground
+        { fdmove -c 1 2
+          ${coreutils}/bin/printf
+            "failed to install default config\n" }
+        exit 1
     '';
   };
 in
@@ -51,18 +47,25 @@ dockerTools.streamLayeredImage {
 
   maxLayers = 125;
 
-  contents = [ entrypoint qbittorrent-nox ];
+  contents = [
+    dockerTools.caCertificates
+    coreutils
+    entrypoint
+    qbittorrent-nox
+  ];
 
   config = {
-    Cmd = [ "/bin/qbittorrent-nox" ];
+    Cmd = [ "qbittorrent-nox" ];
     Entrypoint = [ "/entrypoint" ];
     Env = [
       "XDG_CONFIG_HOME=/config"
-      "XDG_DATA_HOME=/config"
+      "XDG_DATA_HOME=/data"
       "XDG_CACHE_HOME=/cache"
     ];
+    ExposedPorts = { "8080/tcp" = { }; };
     Labels = {
-      "org.opencontainers.image.source" = "https://github.com/becometheteapot/nix-containers";
+      "org.opencontainers.image.source" =
+        "https://github.com/becometheteapot/nix-containers";
     };
   };
 }

--- a/ctrs/qbittorrent-nox/default.nix
+++ b/ctrs/qbittorrent-nox/default.nix
@@ -24,6 +24,7 @@ let
 
       importas -D /config XDG_CONFIG_HOME XDG_CONFIG_HOME
       importas -D /config XDG_DATA_HOME XDG_DATA_HOME
+      importas -D /cache XDG_CACHE_HOME XDG_CACHE_HOME
       importas -D 911 PUID PUID
       importas -D 911 PGID PGID
 
@@ -36,7 +37,10 @@ let
         ${name}
       }
       if { ${coreutils}/bin/mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME }
-      if { ${coreutils}/bin/chown -R ''${PUID}:''${PGID} $XDG_CONFIG_HOME $XDG_DATA_HOME }
+      if { ${coreutils}/bin/chown -R ''${PUID}:''${PGID}
+        $XDG_CONFIG_HOME
+        $XDG_DATA_HOME
+        $XDG_CACHE_HOME }
       ${gosu}/bin/gosu ''${PUID}:''${PGID} $1 $@
     '';
   };
@@ -50,11 +54,12 @@ dockerTools.streamLayeredImage {
   contents = [ entrypoint qbittorrent-nox ];
 
   config = {
-    Cmd = [ "/bin/komga" ];
+    Cmd = [ "/bin/qbittorrent-nox" ];
     Entrypoint = [ "/entrypoint" ];
     Env = [
       "XDG_CONFIG_HOME=/config"
       "XDG_DATA_HOME=/config"
+      "XDG_CACHE_HOME=/cache"
     ];
     Labels = {
       "org.opencontainers.image.source" = "https://github.com/becometheteapot/nix-containers";

--- a/ctrs/socat/default.nix
+++ b/ctrs/socat/default.nix
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2023 Daniel Sampliner <samplinerD@gmail.com>
+#
+# SPDX-License-Identifier: GLWTPL
+
+{ dockerTools
+, socat
+
+, created ? "1970-01-01T00:00:01Z"
+}:
+dockerTools.streamLayeredImage {
+  inherit created;
+  name = socat.pname;
+  tag = socat.version;
+
+  maxLayers = 125;
+
+  config = {
+    Entrypoint = [ "${socat}/bin/socat" ];
+    Labels = {
+      "org.opencontainers.image.source" =
+        "https://github.com/becometheteapot/socat";
+    };
+  };
+}

--- a/fp/ctrs.nix
+++ b/fp/ctrs.nix
@@ -20,6 +20,7 @@ in
         coreutils = pkgs.callPackage ../ctrs/coreutils { inherit created; };
         komga = pkgs.callPackage ../ctrs/komga { inherit created; };
         qbittorrent-nox = pkgs.callPackage ../ctrs/qbittorrent-nox { inherit created; };
+        socat = pkgs.callPackage ../ctrs/socat { inherit created; };
       };
 
       manifest = (pkgs.writeText "manifest" (builtins.toJSON

--- a/fp/ctrs.nix
+++ b/fp/ctrs.nix
@@ -21,6 +21,7 @@ in
         komga = pkgs.callPackage ../ctrs/komga { inherit created; };
         qbittorrent-nox = pkgs.callPackage ../ctrs/qbittorrent-nox { inherit created; };
         socat = pkgs.callPackage ../ctrs/socat { inherit created; };
+        pbr = pkgs.callPackage ../ctrs/pbr { inherit created; };
       };
 
       manifest = (pkgs.writeText "manifest" (builtins.toJSON

--- a/fp/ctrs.nix
+++ b/fp/ctrs.nix
@@ -17,6 +17,7 @@ in
   perSystem = { pkgs, ... }:
     let
       ctrs = {
+        coreutils = pkgs.callPackage ../ctrs/coreutils { inherit created; };
         komga = pkgs.callPackage ../ctrs/komga { inherit created; };
         qbittorrent-nox = pkgs.callPackage ../ctrs/qbittorrent-nox { inherit created; };
       };


### PR DESCRIPTION
No longer run applications as root to allow them to fix permissions
prior to running (with the asumption it will also setuid to drop
privileges).

Instead, introduce separate coreutils container that can run as root to
set ownership/permissions. The orchestrator can then force this to run
prior to the application and pass it all of the same mounted volumes.
This allows the application to be run directly as the less-privileged
user without requiring that user to be baked into the image at build
time.
