### PR TITLE
fix(komga): correct healthcheck port to 25600

### DIFF
--- a/ctrs/komga/default.nix
+++ b/ctrs/komga/default.nix
@@ -31,7 +31,7 @@ dockerTools.streamLayeredImage {
         "CMD"
         "${curl}/bin/curl"
         "-qsS"
-        "localhost:8080"
+        "localhost:25600"
       ];
       StartPeriod = 30 * 1000000000;
       Timeout = 3 * 1000000000;


### PR DESCRIPTION
komga version 1.0.0 changed the default port from 8080 to 25600:

https://github.com/gotson/komga/blob/master/CHANGELOG.md#100-2023-06-28