### PR TITLE
fix(chrony): add PATH environment variable

### DIFF
--- a/ctrs/chrony/default.nix
+++ b/ctrs/chrony/default.nix
@@ -48,6 +48,7 @@ dockerTools.streamLayeredImage {
   config = {
     Cmd = [ "-d" "-r" "-s" "-F" "1" "-u" "nobody" ];
     Entrypoint = [ "chronyd" ];
+    Env = [ "PATH=/bin" ];
     Healthcheck = {
       Test = [ "CMD" "chronyc" "waitsync" "1" ];
       StartInterval = 1 * 1000000000;


### PR DESCRIPTION
This is a workaround for a bug with netdata. If a container has no environment variables, then netdata will fail to map the container's cgroup ID to its name.